### PR TITLE
Remove `sourceMapPathOverrides` from launch.json

### DIFF
--- a/bin/commands/generator/workspace/templates/processed/.vscode/launch.json
+++ b/bin/commands/generator/workspace/templates/processed/.vscode/launch.json
@@ -25,19 +25,13 @@
                 "port": 9222,
                 "request": "attach",
                 "type": "chrome",
-                "urlFilter": "http://localhost/*",
-                "sourceMapPathOverrides": {
-                    "webpack://<%- workspace %>/*": "${workspaceFolder}/*"
-                }
+                "urlFilter": "http://localhost/*"
           },
           {
                 "name": "Launch Chrome",
                 "request": "launch",
                 "type": "chrome",
-                "url": "http://localhost:8080",
-                "sourceMapPathOverrides": {
-                    "webpack://<%- workspace %>/*": "${workspaceFolder}/*"
-                }
+                "url": "http://localhost:8080"
           }
         ]
     }


### PR DESCRIPTION
When using the workspace mode with `visyn w:u` the launch.json has a `sourceMapPathOverrides`. With the new workspace this is not necessary anymore.

![grafik](https://user-images.githubusercontent.com/5851088/187675781-09f6a72c-b677-4071-ae14-bcdf33c07f04.png)
