### PR TITLE
Improved copy command to replicate folder structures

### DIFF
--- a/bin/commands/copy.js
+++ b/bin/commands/copy.js
@@ -1,13 +1,48 @@
-const { call } = require('./utils');
+const glob = require('glob');
+const fs = require('fs-extra');
+const path = require('path');
 
 module.exports = {
   command: 'copy',
   describe: 'Copy assets, styles, and static files to the dist folder',
   handler: () => {
-    call('shx', "--verbose cp -r src/assets/. dist/assets/ || echo 'no assets copied'");
-    call('shx', "--verbose cp -R src/template/. dist/template/ || echo 'no template copied'");
-    call('shx', "--verbose cp -R src/templates/. dist/templates/ || echo 'no templates copied'");
-    call('shx', "--verbose cp -R src/scss/. dist/scss/ || echo 'no scss files copied'");
-    call('shx', '--verbose cp "src/*.{txt,html,ejs,json}" dist/ || echo \'no file copied\'');
+    const srcDir = 'src';
+    const distDir = 'dist';
+    // Files to copy
+    const filePattern = '**/*.@(txt|html|ejs|json|md|scss|css|js|png|jpg|jpeg|gif|svg|ico|webmanifest|xml)';
+
+    // Additional folders to copy
+    const additionalFolders = ['assets', 'template', 'templates', 'scss'];
+
+    // Copy specified folders from source to destination
+    additionalFolders.forEach((folder) => {
+      const srcFolderPath = path.join(srcDir, folder);
+
+      if (fs.existsSync(srcFolderPath)) {
+        const distFolderPath = path.join(distDir, folder);
+
+        // Ensure the destination directory exists
+        fs.ensureDirSync(distFolderPath);
+
+        // Copy the folder from source to destination
+        fs.copySync(srcFolderPath, distFolderPath, { overwrite: true });
+        console.log(`Copied ${srcFolderPath} to ${distFolderPath}`);
+      }
+    });
+
+    // Get a list of files matching the pattern
+    const files = glob.sync(filePattern, { cwd: srcDir });
+    files.forEach((file) => {
+      const srcPath = path.join(srcDir, file);
+      const distPath = path.join(distDir, file);
+
+      // Ensure the destination directory exists
+      const distDirPath = path.dirname(distPath);
+      fs.ensureDirSync(distDirPath);
+
+      // Copy the file from source to destination
+      fs.copyFileSync(srcPath, distPath);
+      console.log(`Copied ${srcPath} to ${distPath}`);
+    });
   },
 };


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Currently, the `cp` commands only copied either folders, or files matching the pattern in the root folder (`src`). This PR updates this with a node script to copy any files matching the pattern in any of the subdirectories, replicates the folder structure exactly as is in the `dist` folder. 


### Screenshots


### Additional notes for the reviewer(s)
How to test: run `yarn run copy` and check if files are copied, if an error occurs, report it here.

-  
Thanks for creating this pull request 🤗
