### PR TITLE
feat: allow setting devtool=false

### DIFF
--- a/config/rspack.config.js
+++ b/config/rspack.config.js
@@ -31,6 +31,7 @@ module.exports = (webpackEnv, argv) => {
   }
 
   const isDevServerOnly = env.dev_server_only?.toLowerCase() === 'true';
+  const devtool = (env.devtool?.toLowerCase() === 'false' ? false : env.devtool) || (isEnvDevelopment ? 'eval-cheap-module-source-map' : 'source-map');
   const isReactRefresh = isDevServer && isEnvDevelopment;
 
   const now = new Date();
@@ -92,7 +93,7 @@ module.exports = (webpackEnv, argv) => {
     mode,
     // Logging noise constrained to errors and warnings
     stats: 'errors-warnings', //  { logging: 'verbose', timings: true, assets: true },
-    devtool: isEnvDevelopment ? 'cheap-module-source-map' : 'source-map',
+    devtool,
     // These are the "entry points" to our application.
     // This means they will be the "root" imports that are included in JS bundle.
     entry: Object.fromEntries(
@@ -105,6 +106,9 @@ module.exports = (webpackEnv, argv) => {
       ? {
         static: path.resolve(workspacePath, 'bundles'),
         compress: true,
+        // Explicitly set hot to true and liveReload to false to ensure that hot is preferred over liveReload
+        hot: true,
+        liveReload: false,
         // Explicitly set the host to ipv4 local address to ensure that the dev server is reachable from the host machine: https://github.com/cypress-io/cypress/issues/25397
         host: '127.0.0.1',
         open: true,


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [ ] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [ ] Branch is up-to-date with the branch to be merged with, i.e., develop
- [ ] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [ ] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [ ] Add type label (e.g., *bug*, *feature*) to this pull request
- [ ] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [ ] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- We have seen that some devtools don't work as well as others, so for now we added the (non-breaking) choice of passing `devtool=false|<other>` to `yarn start`

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
