### PR TITLE
Add curly rule in the ESLint template

### DIFF
--- a/config/eslintrc.template.js
+++ b/config/eslintrc.template.js
@@ -77,6 +77,7 @@ module.exports = ({ tsconfigRootDir }) => ({
     'react/no-unused-class-component-methods': 'warn',
     'react/prop-types': 'off',
     'react/require-default-props': 'off',
+    'curly': [2, "all"],
     'react/static-property-placement': [
       'warn',
       'property assignment',

--- a/config/eslintrc.template.js
+++ b/config/eslintrc.template.js
@@ -77,7 +77,7 @@ module.exports = ({ tsconfigRootDir }) => ({
     'react/no-unused-class-component-methods': 'warn',
     'react/prop-types': 'off',
     'react/require-default-props': 'off',
-    'curly': [2, 'all'],
+    curly: [2, 'all'],
     'react/static-property-placement': [
       'warn',
       'property assignment',

--- a/config/eslintrc.template.js
+++ b/config/eslintrc.template.js
@@ -77,7 +77,7 @@ module.exports = ({ tsconfigRootDir }) => ({
     'react/no-unused-class-component-methods': 'warn',
     'react/prop-types': 'off',
     'react/require-default-props': 'off',
-    'curly': [2, "all"],
+    'curly': [2, 'all'],
     'react/static-property-placement': [
       'warn',
       'property assignment',


### PR DESCRIPTION
Readded the curly rule in eslint. Without it there were patterns like

`if (condition) statement`

instead of

`if (condition) { statement }`

which is considered a code smell by most companies.

(tested in aelixir over resolutions)