### PR TITLE
Fix: Pin eslint plugin react

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-jsx-a11y": "^6.10.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "eslint-plugin-react": "^7.35.2",
+    "eslint-plugin-react": "7.35.2",
     "eslint-plugin-react-compiler": "0.0.0-experimental-b8a7b48-20240830",
     "eslint-plugin-react-hooks": "^4.6.2",
     "fork-ts-checker-webpack-plugin": "^9.0.2",


### PR DESCRIPTION
### Summary of changes
- Due to some errors in the [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react/releases/tag/v7.36.0) package, we need to pin it's version.
- The issue is described [in this ticket](https://github.com/jsx-eslint/eslint-plugin-react/issues/3819) and will be fixed in [this PR](https://github.com/jsx-eslint/eslint-plugin-react/pull/3821)
- It causes errors in our CI, e.g. see [aevidence](https://github.com/datavisyn/aevidence/actions/runs/10810978082/job/30051301133)



### Screenshots
![image](https://github.com/user-attachments/assets/1997171b-4ce8-4be6-8686-f58e6c0ffb53)


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
