### PR TITLE
feat: enable tile graph for RS Doctor in rspack.config.js

### DIFF
--- a/config/rspack.config.js
+++ b/config/rspack.config.js
@@ -363,7 +363,11 @@ module.exports = (webpackEnv, argv) => {
       ].filter(Boolean),
     },
     plugins: [
-      process.env.RSDOCTOR && new RsdoctorRspackPlugin(),
+      process.env.RSDOCTOR && new RsdoctorRspackPlugin({
+        supports: {
+          generateTileGraph: true,
+        }
+      }),
       isReactRefresh && new ReactRefreshPlugin(),
       new DotenvPlugin({
         path: path.join(workspacePath, '.env'), // load this now instead of the ones in '.env'

--- a/config/rspack.config.js
+++ b/config/rspack.config.js
@@ -366,7 +366,7 @@ module.exports = (webpackEnv, argv) => {
       process.env.RSDOCTOR && new RsdoctorRspackPlugin({
         supports: {
           generateTileGraph: true,
-        }
+        },
       }),
       isReactRefresh && new ReactRefreshPlugin(),
       new DotenvPlugin({


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [ ] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- The tile graph was disabled by default with the rspack/rsdoctor release 1.0.0
- This PR enables the tile graph again in the rspack.config.js

### Screenshots

![image](https://github.com/user-attachments/assets/ccc5cfc5-6db6-49ac-97cb-947c8d1ed9a5)



### Additional notes for the reviewer(s)

1. Run `RSDOCTOR=true yarn bundle:prod` 
2. Go to Bundle Size -> Bundle Analyzer Graph

----  
Thanks for creating this pull request 🤗
