### PR TITLE
config: update verbatimModuleSyntax in lenient tsconfig.json

### DIFF
--- a/config/tsconfig.lenient.template.json
+++ b/config/tsconfig.lenient.template.json
@@ -15,7 +15,8 @@
     "esModuleInterop": false,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "preserveWatchOutput": true
+    "preserveWatchOutput": true,
+    "verbatimModuleSyntax": true,
   },
   // Old "moduleResolution": "Node" option required for Cypress
   // https://github.com/cypress-io/cypress/issues/26308#issuecomment-1663592648


### PR DESCRIPTION
### What is `verbatimModuleSyntax`?

- https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax
- https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/#verbatim-module-syntax

### Why do we need it?

- Without `verbatimModuleSyntax`:

![image](https://github.com/user-attachments/assets/c1951274-feb2-40a4-93c0-a84cd07ed175)

We see no errors when an import which can be used only as a `type`. This would lead to increased bundle size, since it would also compile the imports within the module.
Also, coming from https://github.com/datavisyn/visyn_core/pull/575/commits/274fcfb465659cc8d2ea706e31a0cfafe3d64fdc#diff-c767fb22b4d7242d9d2848e5d53d098f77647cf31592ceed92875cbafdce2684, we have run into this problem where the module contained interfaces as well as React imports from a component and the bundler messed up the entire setup which led everything to crash

- With `verbatimModuleSyntax` enabled:

![image](https://github.com/user-attachments/assets/3539d0ee-ffd1-4e76-82f8-5f7186971c08)

We see errors right in the editor which suggests to import `type` instead of the interface name so that it is excluded from bundling.
These lint errors are autofixable (unfortunately not from the CLI)

![image](https://github.com/user-attachments/assets/99edd762-e820-47df-a81f-1c4462b0ebd5)
