### PR TITLE
feat: Disable noUncheckedIndexedAccess since it forces ! anyway

### DIFF
--- a/config/tsconfig.template.json
+++ b/config/tsconfig.template.json
@@ -17,7 +17,7 @@
     "allowSyntheticDefaultImports": true,
     "preserveWatchOutput": true,
     "strict": true,
-    "noUncheckedIndexedAccess": true,
+    "noUncheckedIndexedAccess": false,
     "noImplicitReturns": true,
   },
   // Old "moduleResolution": "Node" option required for Cypress


### PR DESCRIPTION
The problem:

TS cannot (yet) decide if static indexed access is valid or not. Example:

```
// columns is typed as T[] (without undefined/null)
if (columns.length === 3) {
    columns[0]... -> TS error
}
```

Also for loops are not inferable

```
for (let i = 0; i < 3; i++) {
    if (columns[i]) {
        columns[i]... -> TS error
    }
}
```
