### PR TITLE
fix: set exhaustive-deps to error instead of warn

### DIFF
--- a/config/eslintrc.template.js
+++ b/config/eslintrc.template.js
@@ -129,7 +129,7 @@ module.exports = ({ tsconfigRootDir, optimizeImports = true }) => ({
       },
     ],
     'react-compiler/react-compiler': 'warn',
-    'react-hooks/exhaustive-deps': ['warn', {
+    'react-hooks/exhaustive-deps': ['error', {
       additionalHooks: '(useTriggerFrame|useDeepEffect|useDeepMemo|useDeepCallback|useDeepCompareEffect)',
     }],
     /*


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- The exhaustive-deps rule was set to warn by accident, but it should always be an error.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
