### PR TITLE
fix: no-unused-vars warning shown twice

### DIFF
--- a/config/eslintrc.template.js
+++ b/config/eslintrc.template.js
@@ -60,7 +60,15 @@ module.exports = ({ tsconfigRootDir, optimizeImports = true }) => ({
         allowTaggedTemplates: true,
       },
     ],
-    '@typescript-eslint/no-unused-vars': 'warn',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      {
+        vars: 'all',
+        varsIgnorePattern: '^_',
+        args: 'after-used',
+        argsIgnorePattern: '^_',
+      },
+    ],
     'max-classes-per-file': 'off',
     'no-param-reassign': ['warn', { props: true, ignorePropertyModificationsFor: ['state'] }], // Exclude state as required by redux-toolkit: https://redux-toolkit.js.org/usage/immer-reducers#linting-state-mutations
     'import/no-extraneous-dependencies': 'off',
@@ -96,15 +104,7 @@ module.exports = ({ tsconfigRootDir, optimizeImports = true }) => ({
         },
       ],
       'unused-imports/no-unused-imports': 'error',
-      'unused-imports/no-unused-vars': [
-        'warn',
-        {
-          vars: 'all',
-          varsIgnorePattern: '^_',
-          args: 'after-used',
-          argsIgnorePattern: '^_',
-        },
-      ],
+      'unused-imports/no-unused-vars': 'off', // https://github.com/sweepline/eslint-plugin-unused-imports/blob/master/docs/rules/no-unused-vars.md
     } : {
       'import/order': 'error',
     }),


### PR DESCRIPTION
Closes #127 

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] ~Unit tests are written (frontend/backend if applicable)~
- [ ] ~Integration tests are written (if applicable)~

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [ ] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

-  disable `no-unused-vars` of `unused-imports` plugin in favor of `@typescript-eslint`
- move config to the typescript rule

### Screenshots

![image](https://github.com/user-attachments/assets/ebaebc20-f8a5-4aa0-9b23-9262dd9da340)


### Additional notes for the reviewer(s)

For VS code, restart the ESLint server when changing the config

![image](https://github.com/user-attachments/assets/ef215294-ec6d-417e-8c5a-6b1ef385c882)



-  
Thanks for creating this pull request 🤗
