### PR TITLE
feat: add no-restricted-imports rule for lodash and fontawesome

### DIFF
--- a/config/eslintrc.template.js
+++ b/config/eslintrc.template.js
@@ -51,6 +51,23 @@ module.exports = ({ tsconfigRootDir, optimizeImports = true }) => ({
     'no-prototype-builtins': 'warn',
     'no-minusminus': 'off',
     'no-underscore-dangle': 'off',
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [{
+          name: 'lodash',
+          message: 'Please import specific methods from lodash/<util> instead.',
+        },
+        {
+          name: '@fortawesome/free-solid-svg-icons',
+          message: 'Please import specific icons from @fortawesome/free-solid-svg-icons/<icon> instead.',
+        },
+        {
+          name: '@fortawesome/free-regular-svg-icons',
+          message: 'Please import specific icons from @fortawesome/free-regular-svg-icons/<icon> instead.',
+        }],
+      },
+    ],
     '@typescript-eslint/no-explicit-any': 'warn',
     '@typescript-eslint/no-unused-expressions': [
       'error',


### PR DESCRIPTION
Closes https://github.com/datavisyn/visyn_scripts/issues/129

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Restricts import of lodash and fontawesome, see linked issue for details.

### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
