### PR TITLE
deps: remove sass-embedded as it comes with @rsbuild/plugin-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "react-refresh": "^0.16.0",
     "resolve-url-loader": "^5.0.0",
     "rimraf": "~6.0.1",
-    "sass-embedded": "~1.85.0",
     "sass-loader": "^16.0.4",
     "shx": "~0.3.4",
     "tailwindcss": "^3.4.17",


### PR DESCRIPTION
### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [ ] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Fixes the following error. This happens due to hoisting of dependencies, i.e. if a new sass-loader release comes and we pin it to a stricter version, it will be hoisted within node_modules/visyn_scripts/node_modules/sass-loader, causing it to not exist on the top level node_modules, causing an not found issue.

ERROR in ./src/demo/index.initialize.tsx 8:0-35
  × Failed to resolve loader: sass-loader in /visyn_pro, error: RspackResolver(NotFound("sass-loader"))


### Screenshots


### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
